### PR TITLE
[#13] 상품 등록 프로세스 구현

### DIFF
--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/dto/Actor.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/dto/Actor.java
@@ -1,0 +1,5 @@
+package org.flab.hyunsb.application.dto;
+
+public record Actor(Long actorId, Long regionId) {
+
+}

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/output/CategoryOutputPort.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/output/CategoryOutputPort.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.application.output;
+
+import java.util.Optional;
+
+public interface CategoryOutputPort {
+
+    Optional<Long> findIdById(Long id);
+}

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/output/PostOutputPort.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/output/PostOutputPort.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.application.output;
+
+import org.flab.hyunsb.domain.post.Post;
+
+public interface PostOutputPort {
+
+    Long savePost(Post post);
+}

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/service/CategoryService.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/service/CategoryService.java
@@ -1,6 +1,9 @@
 package org.flab.hyunsb.application.service;
 
+import static org.flab.hyunsb.application.exception.message.RegionErrorMessage.INVALID_REGION_ID;
+
 import lombok.RequiredArgsConstructor;
+import org.flab.hyunsb.application.exception.constraint.ConstraintException;
 import org.flab.hyunsb.application.output.CategoryOutputPort;
 import org.flab.hyunsb.application.validator.CategoryValidator;
 import org.springframework.stereotype.Service;
@@ -13,6 +16,7 @@ public class CategoryService implements CategoryValidator {
 
     @Override
     public void validateCategoryId(Long id) {
-        categoryOutputPort.findIdById(id).orElseThrow(IllegalArgumentException::new);
+        categoryOutputPort.findIdById(id).orElseThrow(() ->
+            new ConstraintException(INVALID_REGION_ID.getMessage()));
     }
 }

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/service/CategoryService.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/service/CategoryService.java
@@ -1,0 +1,18 @@
+package org.flab.hyunsb.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.flab.hyunsb.application.output.CategoryOutputPort;
+import org.flab.hyunsb.application.validator.CategoryValidator;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryService implements CategoryValidator {
+
+    private final CategoryOutputPort categoryOutputPort;
+
+    @Override
+    public void validateCategoryId(Long id) {
+        categoryOutputPort.findIdById(id).orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/service/MemberService.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/service/MemberService.java
@@ -39,9 +39,10 @@ public class MemberService implements CreateMemberUseCase, LoginUseCase {
     public String login(MemberForLogin memberForLogin) {
         Member member = memberOutputPort.findByEmail(memberForLogin.email())
             .orElseThrow(MemberNotFoundException::new);
+        regionValidator.validateRegionId(member.getRegionId());
 
         member.tryToLogin(memberForLogin);
 
-        return jwtService.createActorToken(member.getId());
+        return jwtService.createActorToken(member.getId(), member.getRegionId());
     }
 }

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/service/PostService.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/service/PostService.java
@@ -1,0 +1,28 @@
+package org.flab.hyunsb.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.flab.hyunsb.application.output.PostOutputPort;
+import org.flab.hyunsb.application.usecase.post.CreatePostUseCase;
+import org.flab.hyunsb.application.validator.CategoryValidator;
+import org.flab.hyunsb.application.validator.RegionValidator;
+import org.flab.hyunsb.domain.post.Post;
+import org.flab.hyunsb.domain.post.PostForCreate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PostService implements CreatePostUseCase {
+
+    private final PostOutputPort postOutputPort;
+    private final RegionValidator regionValidator;
+    private final CategoryValidator categoryValidator;
+
+    @Override
+    public Long createMember(PostForCreate postForCreate) {
+        regionValidator.validateRegionId(postForCreate.regionId());
+        categoryValidator.validateCategoryId(postForCreate.categoryId());
+
+        Post post = Post.from(postForCreate);
+        return postOutputPort.savePost(post);
+    }
+}

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/service/PostService.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/service/PostService.java
@@ -18,7 +18,7 @@ public class PostService implements CreatePostUseCase {
     private final CategoryValidator categoryValidator;
 
     @Override
-    public Long createMember(PostForCreate postForCreate) {
+    public Long createPost(PostForCreate postForCreate) {
         regionValidator.validateRegionId(postForCreate.regionId());
         categoryValidator.validateCategoryId(postForCreate.categoryId());
 

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/usecase/member/ActorTokenAuthUseCase.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/usecase/member/ActorTokenAuthUseCase.java
@@ -1,6 +1,8 @@
 package org.flab.hyunsb.application.usecase.member;
 
+import org.flab.hyunsb.application.dto.Actor;
+
 public interface ActorTokenAuthUseCase {
 
-    Long authenticate(String actorToken);
+    Actor authenticate(String actorToken);
 }

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/usecase/post/CreatePostUseCase.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/usecase/post/CreatePostUseCase.java
@@ -4,5 +4,5 @@ import org.flab.hyunsb.domain.post.PostForCreate;
 
 public interface CreatePostUseCase {
 
-    Long createMember(PostForCreate postForCreate);
+    Long createPost(PostForCreate postForCreate);
 }

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/usecase/post/CreatePostUseCase.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/usecase/post/CreatePostUseCase.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.application.usecase.post;
+
+import org.flab.hyunsb.domain.post.PostForCreate;
+
+public interface CreatePostUseCase {
+
+    Long createMember(PostForCreate postForCreate);
+}

--- a/used-trading-application/src/main/java/org/flab/hyunsb/application/validator/CategoryValidator.java
+++ b/used-trading-application/src/main/java/org/flab/hyunsb/application/validator/CategoryValidator.java
@@ -1,0 +1,6 @@
+package org.flab.hyunsb.application.validator;
+
+public interface CategoryValidator {
+
+    void validateCategoryId(Long id);
+}

--- a/used-trading-application/src/test/java/org/flab/hyunsb/application/service/actortoken/ActorTokenServiceTest.java
+++ b/used-trading-application/src/test/java/org/flab/hyunsb/application/service/actortoken/ActorTokenServiceTest.java
@@ -6,6 +6,7 @@ import static org.flab.hyunsb.application.exception.message.ActorTokenErrorMessa
 import static org.flab.hyunsb.application.exception.message.ActorTokenErrorMessage.TOKEN_FORMAT_INVALID;
 
 import java.util.Date;
+import org.flab.hyunsb.application.dto.Actor;
 import org.flab.hyunsb.application.exception.authentication.ActorTokenInvalidException;
 import org.flab.hyunsb.application.service.ActorTokenService;
 import org.flab.hyunsb.application.service.actortoken.mock.MockDateGenerator;
@@ -32,12 +33,14 @@ class ActorTokenServiceTest {
     public void createActorToken_successTest() {
         // Given
         Long actorId = 1L;
+        Long regionId = 1L;
         // When
-        String actorToken = actorTokenService.createActorToken(actorId);
-        Long actual = actorTokenService.authenticate(actorToken);
+        String actorToken = actorTokenService.createActorToken(actorId, regionId);
+        Actor actor = actorTokenService.authenticate(actorToken);
         // Then
         Assertions.assertAll(
-            () -> Assertions.assertEquals(actorId, actual)
+            () -> Assertions.assertEquals(actorId, actor.actorId()),
+            () -> Assertions.assertEquals(regionId, actor.regionId())
         );
     }
 
@@ -46,7 +49,8 @@ class ActorTokenServiceTest {
     public void authenticateActorToken_failureTest_invalidToken() {
         // Given
         Long actorId = 1L;
-        String actorToken = actorTokenService.createActorToken(actorId) + "invalid";
+        Long regionId = 1L;
+        String actorToken = actorTokenService.createActorToken(actorId, regionId) + "invalid";
         // When & Then
         Assertions.assertAll(
             () -> assertThatThrownBy(() -> actorTokenService.authenticate(actorToken))
@@ -60,7 +64,8 @@ class ActorTokenServiceTest {
     public void authenticateActorToken_failureTest_invalidTokenFormat() {
         // Given
         Long actorId = 1L;
-        String actorToken = "invalid" + actorTokenService.createActorToken(actorId);
+        Long regionId = 1L;
+        String actorToken = "invalid" + actorTokenService.createActorToken(actorId, regionId);
         // When & Then
         Assertions.assertAll(
             () -> assertThatThrownBy(() -> actorTokenService.authenticate(actorToken))
@@ -74,7 +79,8 @@ class ActorTokenServiceTest {
     public void authenticateActorToken_failureTest_expiredToken() {
         // Given
         Long actorId = 1L;
-        String actorToken = actorTokenService.createActorToken(actorId);
+        Long regionId = 1L;
+        String actorToken = actorTokenService.createActorToken(actorId, regionId);
         mockDateGenerator.setCurrentDate(new Date(System.currentTimeMillis() + 259200000));
         // When & Then
         Assertions.assertAll(

--- a/used-trading-application/src/test/java/org/flab/hyunsb/application/service/category/CategoryServiceTest.java
+++ b/used-trading-application/src/test/java/org/flab/hyunsb/application/service/category/CategoryServiceTest.java
@@ -1,0 +1,57 @@
+package org.flab.hyunsb.application.service.category;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+import org.flab.hyunsb.application.exception.constraint.ConstraintException;
+import org.flab.hyunsb.application.exception.message.RegionErrorMessage;
+import org.flab.hyunsb.application.output.CategoryOutputPort;
+import org.flab.hyunsb.application.service.CategoryService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryServiceTest {
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Mock
+    private CategoryOutputPort categoryOutputPort;
+
+    @Test
+    @DisplayName("[카테고리 식별자 검증 성공 테스트] 유효한 식별자가 주어진 경우 void를 반환한다.")
+    public void validateCategoryId_successTest() {
+        // Given
+        Long categoryId = 1L;
+        Mockito.when(categoryOutputPort.findIdById(ArgumentMatchers.anyLong()))
+            .thenReturn(Optional.of(1L));
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertDoesNotThrow(() ->
+                categoryService.validateCategoryId(categoryId))
+        );
+    }
+
+    @Test
+    @DisplayName("[카테고리 식별자 검증 실패 테스트] 유효하지 않은 식별자가 주어진 경우 예외를 발생한다.")
+    public void validateCategoryId_failureTest() {
+        // Given
+        Long categoryId = 1L;
+        Mockito.when(categoryOutputPort.findIdById(ArgumentMatchers.anyLong()))
+            .thenReturn(Optional.empty());
+        // When & Then
+        Assertions.assertAll(
+            () -> assertThatThrownBy(() -> categoryService.validateCategoryId(categoryId))
+                .isInstanceOf(ConstraintException.class)
+                .hasMessage(RegionErrorMessage.INVALID_REGION_ID.getMessage())
+        );
+    }
+}

--- a/used-trading-application/src/test/java/org/flab/hyunsb/application/service/post/PostServiceTest.java
+++ b/used-trading-application/src/test/java/org/flab/hyunsb/application/service/post/PostServiceTest.java
@@ -40,7 +40,7 @@ public class PostServiceTest {
 
     @BeforeEach
     void setUp() {
-        Images images = Images.generateImagesExcludeThumbnail(List.of("image1", "image2"));
+        Images images = new Images(List.of("image1", "image2"));
         testPostForCreate =
             new PostForCreate(1L, 1L, 1L, new Price(0), "title", "description", images);
     }

--- a/used-trading-application/src/test/java/org/flab/hyunsb/application/service/post/PostServiceTest.java
+++ b/used-trading-application/src/test/java/org/flab/hyunsb/application/service/post/PostServiceTest.java
@@ -1,0 +1,93 @@
+package org.flab.hyunsb.application.service.post;
+
+import java.util.List;
+import org.flab.hyunsb.application.exception.constraint.ConstraintException;
+import org.flab.hyunsb.application.output.PostOutputPort;
+import org.flab.hyunsb.application.service.PostService;
+import org.flab.hyunsb.application.validator.CategoryValidator;
+import org.flab.hyunsb.application.validator.RegionValidator;
+import org.flab.hyunsb.domain.post.Post;
+import org.flab.hyunsb.domain.post.PostForCreate;
+import org.flab.hyunsb.domain.post.Price;
+import org.flab.hyunsb.domain.post.vo.Images;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceTest {
+
+    @InjectMocks
+    private PostService postService;
+
+    @Mock
+    private PostOutputPort postOutputPort;
+
+    @Mock
+    private RegionValidator regionValidator;
+
+    @Mock
+    private CategoryValidator categoryValidator;
+
+    private PostForCreate testPostForCreate;
+
+    @BeforeEach
+    void setUp() {
+        Images images = Images.generateImagesExcludeThumbnail(List.of("image1", "image2"));
+        testPostForCreate =
+            new PostForCreate(1L, 1L, 1L, new Price(0), "title", "description", images);
+    }
+
+    @Test
+    @DisplayName("[게시글 생성 성공 테스트] 게시글을 생성한다.")
+    public void createPost_successTest() {
+        // Given
+        Mockito.doNothing().when(regionValidator).validateRegionId(ArgumentMatchers.anyLong());
+        Mockito.doNothing().when(categoryValidator).validateCategoryId(ArgumentMatchers.anyLong());
+        Mockito.when(postOutputPort.savePost(ArgumentMatchers.any(Post.class))).thenReturn(1L);
+
+        // When
+        Long postId = postService.createPost(testPostForCreate);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(1L, postId)
+        );
+    }
+
+    @Test
+    @DisplayName("[게시글 생성 실패 테스트] 지역 검증에 실패하는 경우 예외를 발생한다.")
+    public void createPost_failureTest_invalidRegionId() {
+        // Given
+        Mockito.doThrow(ConstraintException.class)
+            .when(regionValidator)
+            .validateRegionId(ArgumentMatchers.anyLong());
+
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(ConstraintException.class, () ->
+                postService.createPost(testPostForCreate))
+        );
+    }
+
+    @Test
+    @DisplayName("[게시글 생성 실패 테스트] 카테고리 검증에 실패하는 경우 예외를 발생한다.")
+    public void createPost_failureTest_invalidCategoryId() {
+        // Given
+        Mockito.doNothing().when(regionValidator).validateRegionId(ArgumentMatchers.anyLong());
+        Mockito.doThrow(ConstraintException.class)
+            .when(categoryValidator).validateCategoryId(ArgumentMatchers.anyLong());
+
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(ConstraintException.class, () ->
+                postService.createPost(testPostForCreate))
+        );
+    }
+}

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/config/ActorTokenConfig.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/config/ActorTokenConfig.java
@@ -15,7 +15,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class ActorTokenConfig implements WebMvcConfigurer {
 
     public static final String ACTOR_TOKEN_HEADER = "Authorization";
-    public static final String ACTOR_ID_ATTRIBUTE = "actorId";
+    public static final String ACTOR_ATTRIBUTE = "actor";
 
     private final ActorTokenAuthUseCase actorTokenAuthUseCase;
 

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/actortoken/ActorTokenAuthInterceptor.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/actortoken/ActorTokenAuthInterceptor.java
@@ -1,6 +1,6 @@
 package org.flab.hyunsb.bootstrap.rest.actortoken;
 
-import static org.flab.hyunsb.bootstrap.config.ActorTokenConfig.ACTOR_ID_ATTRIBUTE;
+import static org.flab.hyunsb.bootstrap.config.ActorTokenConfig.ACTOR_ATTRIBUTE;
 import static org.flab.hyunsb.bootstrap.config.ActorTokenConfig.ACTOR_TOKEN_HEADER;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
+import org.flab.hyunsb.application.dto.Actor;
 import org.flab.hyunsb.application.usecase.member.ActorTokenAuthUseCase;
 import org.flab.hyunsb.bootstrap.rest.exception.ActorTokenException;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -23,8 +24,8 @@ public class ActorTokenAuthInterceptor implements HandlerInterceptor {
         Object handler) throws Exception {
 
         String actorToken = getToken(request);
-        Long actorId = actorTokenAuthUseCase.authenticate(actorToken);
-        request.setAttribute(ACTOR_ID_ATTRIBUTE, actorId);
+        Actor actor = actorTokenAuthUseCase.authenticate(actorToken);
+        request.setAttribute(ACTOR_ATTRIBUTE, actor);
 
         return true;
     }

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/actortoken/LoginActorArgumentResolver.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/actortoken/LoginActorArgumentResolver.java
@@ -1,9 +1,10 @@
 package org.flab.hyunsb.bootstrap.rest.actortoken;
 
-import static org.flab.hyunsb.bootstrap.config.ActorTokenConfig.ACTOR_ID_ATTRIBUTE;
+import static org.flab.hyunsb.bootstrap.config.ActorTokenConfig.ACTOR_ATTRIBUTE;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.flab.hyunsb.application.dto.Actor;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -17,13 +18,13 @@ public class LoginActorArgumentResolver implements HandlerMethodArgumentResolver
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(LoginActor.class)
-            && parameter.getParameterType().equals(Long.class);
+            && parameter.getParameterType().equals(Actor.class);
     }
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
         NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
-        return webRequest.getAttribute(ACTOR_ID_ATTRIBUTE, 0);
+        return webRequest.getAttribute(ACTOR_ATTRIBUTE, 0);
     }
 }

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/MemberRestAdapter.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/MemberRestAdapter.java
@@ -49,4 +49,3 @@ public class MemberRestAdapter {
         response.setHeader(ACTOR_TOKEN_HEADER, accessToken);
     }
 }
-

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapter.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapter.java
@@ -1,0 +1,34 @@
+package org.flab.hyunsb.bootstrap.rest.adapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.flab.hyunsb.application.dto.Actor;
+import org.flab.hyunsb.application.usecase.post.CreatePostUseCase;
+import org.flab.hyunsb.bootstrap.rest.actortoken.LoginActor;
+import org.flab.hyunsb.bootstrap.rest.dto.post.PostCreateRequest;
+import org.flab.hyunsb.domain.post.PostForCreate;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/post")
+@RestController
+public class PostRestAdapter {
+
+    private final CreatePostUseCase createPostUseCase;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Long createPost(@LoginActor Actor actor,
+        @RequestBody PostCreateRequest postCreateRequest) {
+
+        PostForCreate postForCreate = postCreateRequest.toDomain(actor.actorId(), actor.regionId());
+
+        return createPostUseCase.createPost(postForCreate);
+    }
+}

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapter.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapter.java
@@ -1,5 +1,6 @@
 package org.flab.hyunsb.bootstrap.rest.adapter;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.flab.hyunsb.application.dto.Actor;
@@ -16,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/post")
+@RequestMapping("/api/v1/posts")
 @RestController
 public class PostRestAdapter {
 
@@ -25,7 +26,7 @@ public class PostRestAdapter {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public Long createPost(@LoginActor Actor actor,
-        @RequestBody PostCreateRequest postCreateRequest) {
+        @Valid @RequestBody PostCreateRequest postCreateRequest) {
 
         PostForCreate postForCreate = postCreateRequest.toDomain(actor.actorId(), actor.regionId());
 

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostCreateRequest.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostCreateRequest.java
@@ -1,5 +1,7 @@
 package org.flab.hyunsb.bootstrap.rest.dto.post;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -28,23 +30,18 @@ public class PostCreateRequest {
     @NotNull
     private Integer price;
 
+    @NotNull
+    @Min(value = 0)
+    @Max(value = 10)
     private Integer thumbnailNumber;
 
     @NotNull
     private List<String> images;
 
     public PostForCreate toDomain(Long memberId, Long regionId) {
-        Images images = generateImages(thumbnailNumber, this.images);
+        Images images = new Images(thumbnailNumber, this.images);
         Price price = new Price(this.price);
 
         return new PostForCreate(memberId, regionId, categoryId, price, title, description, images);
     }
-
-    private Images generateImages(Integer thumbnailNumber, List<String> images) {
-        if (thumbnailNumber == null) {
-            return Images.generateImagesExcludeThumbnail(images);
-        }
-        return Images.generateImagesIncludeThumbnail(thumbnailNumber, images);
-    }
-
 }

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostCreateRequest.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostCreateRequest.java
@@ -1,0 +1,50 @@
+package org.flab.hyunsb.bootstrap.rest.dto.post;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.flab.hyunsb.domain.post.PostForCreate;
+import org.flab.hyunsb.domain.post.Price;
+import org.flab.hyunsb.domain.post.vo.Images;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCreateRequest {
+
+    @NotNull
+    private Long categoryId;
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String description;
+
+    @NotNull
+    private Integer price;
+
+    private Integer thumbnailNumber;
+
+    @NotNull
+    private List<String> images;
+
+    public PostForCreate toDomain(Long memberId, Long regionId) {
+        Images images = generateImages(thumbnailNumber, this.images);
+        Price price = new Price(this.price);
+
+        return new PostForCreate(memberId, regionId, categoryId, price, title, description, images);
+    }
+
+    private Images generateImages(Integer thumbnailNumber, List<String> images) {
+        if (thumbnailNumber == null) {
+            return Images.generateImagesExcludeThumbnail(images);
+        }
+        return Images.generateImagesIncludeThumbnail(thumbnailNumber, images);
+    }
+
+}

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/ExceptionControllerAdvice.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/ExceptionControllerAdvice.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.flab.hyunsb.application.exception.authentication.AuthenticationException;
 import org.flab.hyunsb.application.exception.constraint.ConstraintException;
 import org.flab.hyunsb.domain.exception.MemberAuthException;
+import org.flab.hyunsb.domain.exception.PasswordConstraintException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -31,7 +32,7 @@ public class ExceptionControllerAdvice {
         );
     }
 
-    @ExceptionHandler(ConstraintException.class)
+    @ExceptionHandler({ConstraintException.class, PasswordConstraintException.class})
     public ErrorResponse constraintException(
         ConstraintException exception, HttpServletRequest request) {
         logError(exception, request.getRequestURL().toString());

--- a/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/actortoken/ActorTokenAuthInterceptorTest.java
+++ b/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/actortoken/ActorTokenAuthInterceptorTest.java
@@ -1,0 +1,73 @@
+package org.flab.hyunsb.bootstrap.rest.actortoken;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.flab.hyunsb.application.dto.Actor;
+import org.flab.hyunsb.application.usecase.member.ActorTokenAuthUseCase;
+import org.flab.hyunsb.bootstrap.rest.exception.ActorTokenException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ActorTokenAuthInterceptorTest {
+
+    @InjectMocks
+    private ActorTokenAuthInterceptor actorTokenAuthInterceptor;
+
+    @Mock
+    private ActorTokenAuthUseCase actorTokenAuthUseCase;
+
+    private HttpServletRequest mockRequest;
+    private HttpServletResponse mockResponse;
+    private Object mockHandler;
+
+    @BeforeEach
+    void setUp() {
+        mockRequest = Mockito.mock(HttpServletRequest.class);
+        mockResponse = Mockito.mock(HttpServletResponse.class);
+        mockHandler = new Object();
+    }
+
+    @Test
+    @DisplayName("[엑터 토큰 파싱 성공 테스트] 유효한 토큰이 제공된 경우 preHandle 호출 시 true를 반환한다.")
+    public void actorTokenParsing_successTest() throws Exception {
+        // Given
+        Mockito.when(mockRequest.getHeader("Authorization"))
+            .thenReturn("valid_token");
+
+        Actor actor = new Actor(1L, 1L);
+        Mockito.when(actorTokenAuthUseCase.authenticate(ArgumentMatchers.anyString()))
+            .thenReturn(actor);
+
+        // When
+        boolean result =
+            actorTokenAuthInterceptor.preHandle(mockRequest, mockResponse, mockHandler);
+
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertTrue(result)
+        );
+    }
+
+    @Test
+    @DisplayName("[엑터 토큰 파싱 실패 테스트] 토큰이 존재하지 않는 경우 예외를 발생한다.")
+    public void actorTokenParsing_failureTest() {
+        // Given
+        Mockito.when(mockRequest.getHeader("Authorization"))
+            .thenReturn(null);
+
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(ActorTokenException.class, () ->
+                actorTokenAuthInterceptor.preHandle(mockRequest, mockResponse, mockHandler))
+        );
+    }
+}

--- a/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/actortoken/LoginActorArgumentResolverTest.java
+++ b/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/actortoken/LoginActorArgumentResolverTest.java
@@ -1,0 +1,74 @@
+package org.flab.hyunsb.bootstrap.rest.actortoken;
+
+import org.flab.hyunsb.application.dto.Actor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+
+@ExtendWith(MockitoExtension.class)
+public class LoginActorArgumentResolverTest {
+
+    @InjectMocks
+    private LoginActorArgumentResolver loginActorArgumentResolver;
+
+    private MethodParameter mockMethodParameter;
+
+    @BeforeEach
+    void setUp() {
+        mockMethodParameter = Mockito.mock(MethodParameter.class);
+    }
+
+    @Test
+    @DisplayName("[아규먼트 리졸버 동작 성공 테스트] 동작 조건에 부합하는 경우 true를 반환한다.")
+    public void resolveArgument_successTest() {
+        // Given
+        Mockito.when(mockMethodParameter.hasParameterAnnotation(LoginActor.class))
+            .thenReturn(true);
+
+        Mockito.when(mockMethodParameter.getParameterType())
+            .thenReturn((Class) Actor.class);
+        // When
+        boolean result = loginActorArgumentResolver.supportsParameter(mockMethodParameter);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertTrue(result)
+        );
+    }
+
+    @Test
+    @DisplayName("[아규먼트 리졸버 동작 실패 테스트] 조건에 부합하는 애노테이션이 포함되어 있지 않은 경우 false를 반환한다.")
+    public void resolveArgument_failureTest_excludeAnnotation() {
+        // Given
+        Mockito.when(mockMethodParameter.hasParameterAnnotation(LoginActor.class))
+            .thenReturn(false);
+        // When
+        boolean result = loginActorArgumentResolver.supportsParameter(mockMethodParameter);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertFalse(result)
+        );
+    }
+
+    @Test
+    @DisplayName("[아규먼트 리졸버 동작 실패 테스트] 조건에 부합하지 않는 타입인 경우 false를 반환한다.")
+    public void resolveArgument_failureTest() {
+        // Given
+        Mockito.when(mockMethodParameter.hasParameterAnnotation(LoginActor.class))
+            .thenReturn(true);
+
+        Mockito.when(mockMethodParameter.getParameterType())
+            .thenReturn((Class) Long.class);
+        // When
+        boolean result = loginActorArgumentResolver.supportsParameter(mockMethodParameter);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertFalse(result)
+        );
+    }
+}

--- a/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapterTest.java
+++ b/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapterTest.java
@@ -35,12 +35,11 @@ class PostRestAdapterTest extends AbstractRestDocsTests {
     private ActorTokenAuthUseCase actorTokenAuthUseCase;
 
     @ParameterizedTest
-    @ValueSource(ints = {1, -1})
+    @ValueSource(ints = {1, 0})
     @DisplayName("[게시글 등록 핸들러 성공 테스트] 게시글 등록 성공 시 해당 게시글의 식별자를 반환한다.")
-    public void registrationMember_successTest(int thumbnail) throws Exception {
+    public void registrationMember_successTest(Integer thumbnailNumber) throws Exception {
         // Given
         String requestUrl = "/api/v1/posts";
-        Integer thumbnailNumber = thumbnail > 0 ? thumbnail : null;
         when(actorTokenAuthUseCase.authenticate(ArgumentMatchers.anyString()))
             .thenReturn(new Actor(1L, 1L));
 

--- a/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapterTest.java
+++ b/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestAdapterTest.java
@@ -1,0 +1,62 @@
+package org.flab.hyunsb.bootstrap.rest.adapter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.flab.hyunsb.application.dto.Actor;
+import org.flab.hyunsb.application.usecase.member.ActorTokenAuthUseCase;
+import org.flab.hyunsb.application.usecase.post.CreatePostUseCase;
+import org.flab.hyunsb.bootstrap.rest.dto.post.PostCreateRequest;
+import org.flab.hyunsb.bootstrap.restdocs.AbstractRestDocsTests;
+import org.flab.hyunsb.domain.post.PostForCreate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(PostRestAdapter.class)
+class PostRestAdapterTest extends AbstractRestDocsTests {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CreatePostUseCase createPostUseCase;
+
+    @MockBean
+    private ActorTokenAuthUseCase actorTokenAuthUseCase;
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, -1})
+    @DisplayName("[게시글 등록 핸들러 성공 테스트] 게시글 등록 성공 시 해당 게시글의 식별자를 반환한다.")
+    public void registrationMember_successTest(int thumbnail) throws Exception {
+        // Given
+        String requestUrl = "/api/v1/posts";
+        Integer thumbnailNumber = thumbnail > 0 ? thumbnail : null;
+        when(actorTokenAuthUseCase.authenticate(ArgumentMatchers.anyString()))
+            .thenReturn(new Actor(1L, 1L));
+
+        String requestBody = objectMapper.writeValueAsString(
+            new PostCreateRequest(
+                1L, "title", "description", 1000, thumbnailNumber, List.of("Image1", "Image2"))
+        );
+
+        when(createPostUseCase.createPost(any(PostForCreate.class)))
+            .thenReturn(1L);
+
+        // When & Then
+        mockMvc.perform(post(requestUrl)
+                .content(requestBody)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "testToken"))
+            .andExpect(status().isCreated());
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/ErrorMessage.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/ErrorMessage.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum ErrorMessage {
 
     LOGIN_FAILED("로그인 실패: 올바른 정보를 입력하세요."),
-    PASSWORD_NOT_MATCHED("비밀번호가 일치하지 않습니다.");
+    CREATE_PASSWORD_FAILED("비밀번호 생성 실패");
 
     private final String message;
 }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/ErrorMessage.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/ErrorMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ErrorMessage {
 
     LOGIN_FAILED("로그인 실패: 올바른 정보를 입력하세요."),
-    CREATE_PASSWORD_FAILED("비밀번호 생성 실패");
+    CREATE_PASSWORD_FAILED("비밀번호 생성 실패"),
+    PASSWORD_NOT_MATCHED("비밀번호가 일치하지 않습니다.");
 
     private final String message;
 }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/PasswordConstraintException.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/PasswordConstraintException.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.domain.exception;
+
+public class PasswordConstraintException extends MemberAuthException {
+
+    public PasswordConstraintException() {
+        super(ErrorMessage.CREATE_PASSWORD_FAILED);
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/PasswordNotMatchedException.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/exception/PasswordNotMatchedException.java
@@ -1,8 +1,0 @@
-package org.flab.hyunsb.domain.exception;
-
-public class PasswordNotMatchedException extends MemberAuthException {
-
-    public PasswordNotMatchedException() {
-        super(ErrorMessage.PASSWORD_NOT_MATCHED);
-    }
-}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/member/Member.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/member/Member.java
@@ -1,8 +1,11 @@
 package org.flab.hyunsb.domain.member;
 
+import static org.flab.hyunsb.domain.exception.ErrorMessage.PASSWORD_NOT_MATCHED;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.flab.hyunsb.domain.exception.LoginFailureException;
+import org.flab.hyunsb.domain.exception.MemberAuthException;
 
 @Getter
 @AllArgsConstructor
@@ -41,7 +44,7 @@ public class Member {
 
     public void changePassword(String currentPassword, String newPassword) {
         if (!password.isMatch(currentPassword)) {
-            throw new IllegalArgumentException();
+            throw new MemberAuthException(PASSWORD_NOT_MATCHED);
         }
         password = Password.generateWithEncrypting(newPassword);
     }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/member/Password.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/member/Password.java
@@ -1,7 +1,7 @@
 package org.flab.hyunsb.domain.member;
 
 import lombok.Getter;
-import org.flab.hyunsb.domain.exception.PasswordNotMatchedException;
+import org.flab.hyunsb.domain.exception.PasswordConstraintException;
 import org.flab.hyunsb.domain.member.encryptor.Encryptor;
 import org.flab.hyunsb.domain.member.encryptor.PasswordEncryptor;
 
@@ -19,7 +19,7 @@ public class Password {
 
     private static void validatePassword(String password) {
         if (password.isBlank()) {
-            throw new PasswordNotMatchedException();
+            throw new PasswordConstraintException();
         }
     }
 

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Post.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Post.java
@@ -21,8 +21,11 @@ public class Post {
 
     private Status status;
     private Price price;
+
+    private String title;
     private String description;
     private Images images;
+
     private Count viewCount;
     private Count likeCount;
 
@@ -34,6 +37,7 @@ public class Post {
             .categoryId(postForCreate.categoryId())
             .status(Status.SELLING)
             .price(postForCreate.price())
+            .title(postForCreate.title())
             .description(postForCreate.description())
             .images(postForCreate.images())
             .viewCount(new Count())

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Post.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Post.java
@@ -1,0 +1,43 @@
+package org.flab.hyunsb.domain.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.flab.hyunsb.domain.post.vo.Count;
+import org.flab.hyunsb.domain.post.vo.Images;
+import org.flab.hyunsb.domain.post.vo.Status;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class Post {
+
+    private final Long postId;
+    private final Long memberId;
+    private final Long regionId;
+    private final Long categoryId;
+
+    private Status status;
+    private Price price;
+    private String description;
+    private Images images;
+    private Count viewCount;
+    private Count likeCount;
+
+    public static Post from(PostForCreate postForCreate) {
+        return Post.builder()
+            .postId(null)
+            .memberId(postForCreate.memberId())
+            .regionId(postForCreate.regionId())
+            .categoryId(postForCreate.categoryId())
+            .status(Status.SELLING)
+            .price(postForCreate.price())
+            .description(postForCreate.description())
+            .images(postForCreate.images())
+            .viewCount(new Count())
+            .likeCount(new Count())
+            .build();
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/PostForCreate.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/PostForCreate.java
@@ -5,5 +5,4 @@ import org.flab.hyunsb.domain.post.vo.Images;
 public record PostForCreate(long memberId, long regionId, long categoryId,
                             Price price, String title, String description, Images images) {
 
-
 }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/PostForCreate.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/PostForCreate.java
@@ -3,7 +3,7 @@ package org.flab.hyunsb.domain.post;
 import org.flab.hyunsb.domain.post.vo.Images;
 
 public record PostForCreate(long memberId, long regionId, long categoryId,
-                            Price price, String description, Images images) {
+                            Price price, String title, String description, Images images) {
 
 
 }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/PostForCreate.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/PostForCreate.java
@@ -1,0 +1,9 @@
+package org.flab.hyunsb.domain.post;
+
+import org.flab.hyunsb.domain.post.vo.Images;
+
+public record PostForCreate(long memberId, long regionId, long categoryId,
+                            Price price, String description, Images images) {
+
+
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Price.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Price.java
@@ -1,0 +1,29 @@
+package org.flab.hyunsb.domain.post;
+
+import lombok.Getter;
+import org.flab.hyunsb.domain.post.exception.PostConstraintException;
+
+@Getter
+public class Price {
+
+    private static final int MIN_PRICE = 0;
+    private static final int MAX_PRICE = 999_999_999;
+
+    private int price;
+
+    public Price(int price) {
+        validatePrice(price);
+        this.price = price;
+    }
+
+    private void validatePrice(int price) {
+        if (price < MIN_PRICE || price > MAX_PRICE) {
+            throw new PostConstraintException();
+        }
+    }
+
+    private void changePrice(int price) {
+        validatePrice(price);
+        this.price = price;
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Price.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/Price.java
@@ -21,9 +21,4 @@ public class Price {
             throw new PostConstraintException();
         }
     }
-
-    private void changePrice(int price) {
-        validatePrice(price);
-        this.price = price;
-    }
 }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/exception/PostConstraintException.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/exception/PostConstraintException.java
@@ -1,0 +1,12 @@
+package org.flab.hyunsb.domain.post.exception;
+
+public class PostConstraintException extends RuntimeException {
+
+    public PostConstraintException() {
+
+    }
+
+    public PostConstraintException(String message) {
+        super(message);
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Count.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Count.java
@@ -1,0 +1,55 @@
+package org.flab.hyunsb.domain.post.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.flab.hyunsb.domain.post.exception.PostConstraintException;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Count {
+
+    private int count;
+
+    public void increaseCount() {
+        increaseCount(1);
+    }
+
+    public void increaseCount(int number) {
+        validateNumberForChangeCount(number);
+        changeCount(number);
+    }
+
+    private void validateNumberForChangeCount(int number) {
+        if (number <= 0) {
+            throw new PostConstraintException("변경할 수는 음수일 수 없음");
+        }
+    }
+
+    private void changeCount(int number) {
+        count += number;
+    }
+
+    public void decreaseCount() {
+        decreaseCount(1);
+    }
+
+    /*
+    * 카운트 감소 작업에서 동시성 문제 밠애시 카운트가 음수로 변경될 가능성이 존재한다.
+    * 카운트 증가 작업은 데이터가 누락되어도 문제가 되지 않으니
+    * AtomicInteger로 동시성을 처리할 경우 성능 오버헤드가 발생할 수 있다.
+    * 따라서 카운트 감소 작업만 동기화 처리한다.
+    * */
+    public synchronized void decreaseCount(int number) {
+        validateNumberForChangeCount(number);
+        validateIsPossibleDecrease(number);
+        changeCount(-number);
+    }
+
+    private void validateIsPossibleDecrease(int number) {
+        if (count - number < 0) {
+            throw new PostConstraintException("카운트를 감소시킬 수 없음");
+        }
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Count.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Count.java
@@ -35,12 +35,6 @@ public class Count {
         decreaseCount(1);
     }
 
-    /*
-    * 카운트 감소 작업에서 동시성 문제 밠애시 카운트가 음수로 변경될 가능성이 존재한다.
-    * 카운트 증가 작업은 데이터가 누락되어도 문제가 되지 않으니
-    * AtomicInteger로 동시성을 처리할 경우 성능 오버헤드가 발생할 수 있다.
-    * 따라서 카운트 감소 작업만 동기화 처리한다.
-    * */
     public synchronized void decreaseCount(int number) {
         validateNumberForChangeCount(number);
         validateIsPossibleDecrease(number);

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Images.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Images.java
@@ -1,0 +1,37 @@
+package org.flab.hyunsb.domain.post.vo;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.flab.hyunsb.domain.post.exception.PostConstraintException;
+
+@Getter
+@AllArgsConstructor
+public class Images {
+
+    private String thumbnail;
+    private List<String> images;
+
+    public static Images generateImagesExcludeThumbnail(List<String> images) {
+        validateImages(images);
+        return generateImagesIncludeThumbnail(0, images);
+    }
+
+    private static void validateImages(List<String> images) {
+        if (images.isEmpty()) {
+            throw new PostConstraintException("이미지는 필수");
+        }
+    }
+
+    public static Images generateImagesIncludeThumbnail(int thumbnailNumber, List<String> images) {
+        validateImages(images);
+        validateThumbnailNumber(thumbnailNumber, images.size());
+        return new Images(images.get(thumbnailNumber), images);
+    }
+
+    private static void validateThumbnailNumber(int thumbnailNumber, int imageNumber) {
+        if (thumbnailNumber >= imageNumber) {
+            throw new PostConstraintException("썸네일 번호가 유효하지 않음");
+        }
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Images.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Images.java
@@ -1,5 +1,6 @@
 package org.flab.hyunsb.domain.post.vo;
 
+import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 import org.flab.hyunsb.domain.post.exception.PostConstraintException;
@@ -34,5 +35,9 @@ public class Images {
         if (thumbnailNumber >= imageNumber) {
             throw new PostConstraintException("썸네일 번호가 유효하지 않음");
         }
+    }
+
+    public List<String> getImages() {
+        return Collections.unmodifiableList(images);
     }
 }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Images.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Images.java
@@ -1,35 +1,36 @@
 package org.flab.hyunsb.domain.post.vo;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.flab.hyunsb.domain.post.exception.PostConstraintException;
 
 @Getter
-@AllArgsConstructor
 public class Images {
+
+    private static final int DEFAULT_THUMBNAIL_NUMBER = 0;
 
     private String thumbnail;
     private List<String> images;
 
-    public static Images generateImagesExcludeThumbnail(List<String> images) {
-        validateImages(images);
-        return generateImagesIncludeThumbnail(0, images);
+    public Images(List<String> images) {
+        this(DEFAULT_THUMBNAIL_NUMBER, images);
     }
 
-    private static void validateImages(List<String> images) {
+    public Images(int thumbnailNumber, List<String> images) {
+        validateImages(images);
+        validateThumbnailNumber(thumbnailNumber, images.size());
+
+        thumbnail = images.get(thumbnailNumber);
+        this.images = images;
+    }
+
+    private void validateImages(List<String> images) {
         if (images.isEmpty()) {
             throw new PostConstraintException("이미지는 필수");
         }
     }
 
-    public static Images generateImagesIncludeThumbnail(int thumbnailNumber, List<String> images) {
-        validateImages(images);
-        validateThumbnailNumber(thumbnailNumber, images.size());
-        return new Images(images.get(thumbnailNumber), images);
-    }
-
-    private static void validateThumbnailNumber(int thumbnailNumber, int imageNumber) {
+    private void validateThumbnailNumber(int thumbnailNumber, int imageNumber) {
         if (thumbnailNumber >= imageNumber) {
             throw new PostConstraintException("썸네일 번호가 유효하지 않음");
         }

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Status.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/post/vo/Status.java
@@ -1,0 +1,9 @@
+package org.flab.hyunsb.domain.post.vo;
+
+public enum Status {
+
+    RESERVED,
+    SOLD,
+    SELLING,
+    HIDE;
+}

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/member/MemberTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/member/MemberTest.java
@@ -1,9 +1,11 @@
 package org.flab.hyunsb.domain.member;
 
 import org.flab.hyunsb.domain.exception.LoginFailureException;
+import org.flab.hyunsb.domain.exception.MemberAuthException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MemberTest {
@@ -36,41 +38,81 @@ class MemberTest {
         );
     }
 
-    @Test
-    @DisplayName("[로그인 시도 성공 테스트] 회원 도메인의 정보와 일치하는 정보인 경우 매서드 호출을 종료한다.")
-    public void memberTryToLogin_successTest() {
-        // Given
-        Member member = Member.from(memberForCreate);
-        MemberForLogin memberForLogin = new MemberForLogin(TEST_EMAIL, TEST_PASSWORD);
-        // When & Then
-        Assertions.assertAll(
-            () -> Assertions.assertDoesNotThrow(() -> member.tryToLogin(memberForLogin))
-        );
+    @Nested
+    @DisplayName("회원 도메인 로그인 시도 단위 테스트")
+    class MemberTryToLogin {
+
+        @Test
+        @DisplayName("[로그인 시도 성공 테스트] 회원 도메인의 정보와 일치하는 정보인 경우 매서드 호출을 종료한다.")
+        public void memberTryToLogin_successTest() {
+            // Given
+            Member member = Member.from(memberForCreate);
+            MemberForLogin memberForLogin = new MemberForLogin(TEST_EMAIL, TEST_PASSWORD);
+            // When & Then
+            Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(() -> member.tryToLogin(memberForLogin))
+            );
+        }
+
+        @Test
+        @DisplayName("[로그인 시도 실패 테스트] 회원 정보와 일치하지 않는 이메일이 주어진 경우 예외를 발생한다.")
+        public void memberTryToLogin_failureTest_notMatchEmail() {
+            // Given
+            Member member = Member.from(memberForCreate);
+            MemberForLogin memberForLogin = new MemberForLogin("notMatchedEmail", TEST_PASSWORD);
+            // When & Then
+            Assertions.assertAll(
+                () -> Assertions.assertThrows(LoginFailureException.class, () ->
+                    member.tryToLogin(memberForLogin))
+            );
+        }
+
+        @Test
+        @DisplayName("[로그인 시도 실패 테스트] 회원 정보와 일치하지 않는 비밀번호가 주어진 경우 예외를 발생한다.")
+        public void memberTryToLogin_failureTest_notMatchPassword() {
+            // Given
+            Member member = Member.from(memberForCreate);
+            MemberForLogin memberForLogin = new MemberForLogin(TEST_EMAIL, "notMatchedPassword");
+            // When & Then
+            Assertions.assertAll(
+                () -> Assertions.assertThrows(LoginFailureException.class, () ->
+                    member.tryToLogin(memberForLogin))
+            );
+        }
     }
 
-    @Test
-    @DisplayName("[로그인 시도 실패 테스트] 회원 정보와 일치하지 않는 이메일이 주어진 경우 예외를 발생한다.")
-    public void memberTryToLogin_failureTest_notMatchEmail() {
-        // Given
-        Member member = Member.from(memberForCreate);
-        MemberForLogin memberForLogin = new MemberForLogin("notMatchedEmail", TEST_PASSWORD);
-        // When & Then
-        Assertions.assertAll(
-            () -> Assertions.assertThrows(LoginFailureException.class, () ->
-                member.tryToLogin(memberForLogin))
-        );
-    }
+    @Nested
+    @DisplayName("회원 비밀번호 변경 단위 테스트")
+    class MemberChangePassword {
 
-    @Test
-    @DisplayName("[로그인 시도 실패 테스트] 회원 정보와 일치하지 않는 비밀번호가 주어진 경우 예외를 발생한다.")
-    public void memberTryToLogin_failureTest_notMatchPassword() {
-        // Given
-        Member member = Member.from(memberForCreate);
-        MemberForLogin memberForLogin = new MemberForLogin(TEST_EMAIL, "notMatchedPassword");
-        // When & Then
-        Assertions.assertAll(
-            () -> Assertions.assertThrows(LoginFailureException.class, () ->
-                member.tryToLogin(memberForLogin))
-        );
+        @Test
+        @DisplayName("[회원 비밀번호 변경 성공 테스트] 패스워드 정보가 일치하는 경우 새로운 패스워드로 변경한다.")
+        public void memberChangePassword_successTest() {
+            // Given
+            Member member = Member.from(memberForCreate);
+            String currentPassword = TEST_PASSWORD;
+            String newPassword = "newPassword";
+            MemberForLogin memberForLogin = new MemberForLogin(TEST_EMAIL, newPassword);
+            // When
+            member.changePassword(currentPassword, newPassword);
+            // Then
+            Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(() -> member.tryToLogin(memberForLogin))
+            );
+        }
+
+        @Test
+        @DisplayName("[회원 비밀번호 변경 실패 테스트] 패스워드 정보가 일치하는 않는 경우 예외를 발생한다.")
+        public void memberTryToLogin_failureTest_notMatchPassword() {
+            // Given
+            Member member = Member.from(memberForCreate);
+            String currentPassword = "nonMatchingPassword";
+            String newPassword = "newPassword";
+            // When & Then
+            Assertions.assertAll(
+                () -> Assertions.assertThrows(MemberAuthException.class, () ->
+                    member.changePassword(currentPassword, newPassword))
+            );
+        }
     }
 }

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/member/PasswordTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/member/PasswordTest.java
@@ -1,5 +1,6 @@
 package org.flab.hyunsb.domain.member;
 
+import org.flab.hyunsb.domain.exception.PasswordConstraintException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,9 +38,9 @@ public class PasswordTest {
         String emptyPassword = " ";
         // When & Then
         Assertions.assertAll(
-            () -> Assertions.assertThrows(IllegalArgumentException.class, () ->
+            () -> Assertions.assertThrows(PasswordConstraintException.class, () ->
                 Password.valueOf(emptyPassword)),
-            () -> Assertions.assertThrows(IllegalArgumentException.class, () ->
+            () -> Assertions.assertThrows(PasswordConstraintException.class, () ->
                 Password.generateWithEncrypting(emptyPassword))
         );
     }

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PostTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PostTest.java
@@ -14,8 +14,10 @@ public class PostTest {
         // Given
         Price price = new Price(100);
         String description = "testDescription";
+        String title = "testTitle";
         Images images = Images.generateImagesExcludeThumbnail(List.of("image1"));
-        PostForCreate postForCreate = new PostForCreate(1L, 2L, 3L, price, description, images);
+        PostForCreate postForCreate =
+            new PostForCreate(1L, 2L, 3L, price, title, description, images);
         // When
         Post post = Post.from(postForCreate);
         // Then
@@ -25,6 +27,7 @@ public class PostTest {
             () -> Assertions.assertEquals(2L, post.getRegionId()),
             () -> Assertions.assertEquals(3L, post.getCategoryId()),
             () -> Assertions.assertEquals(price, post.getPrice()),
+            () -> Assertions.assertEquals(title, post.getTitle()),
             () -> Assertions.assertEquals(description, post.getDescription()),
             () -> Assertions.assertEquals(images, post.getImages())
         );

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PostTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PostTest.java
@@ -1,0 +1,32 @@
+package org.flab.hyunsb.domain.post;
+
+import java.util.List;
+import org.flab.hyunsb.domain.post.vo.Images;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PostTest {
+
+    @Test
+    @DisplayName("[post 생성 성공 테스트] PostForCreate 로부터 Post 애그리거트를 생성한다.")
+    public void generatePost_successTest_fromPostForCreate() {
+        // Given
+        Price price = new Price(100);
+        String description = "testDescription";
+        Images images = Images.generateImagesExcludeThumbnail(List.of("image1"));
+        PostForCreate postForCreate = new PostForCreate(1L, 2L, 3L, price, description, images);
+        // When
+        Post post = Post.from(postForCreate);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertNull(post.getPostId()),
+            () -> Assertions.assertEquals(1L, post.getMemberId()),
+            () -> Assertions.assertEquals(2L, post.getRegionId()),
+            () -> Assertions.assertEquals(3L, post.getCategoryId()),
+            () -> Assertions.assertEquals(price, post.getPrice()),
+            () -> Assertions.assertEquals(description, post.getDescription()),
+            () -> Assertions.assertEquals(images, post.getImages())
+        );
+    }
+}

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PostTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PostTest.java
@@ -15,7 +15,8 @@ public class PostTest {
         Price price = new Price(100);
         String description = "testDescription";
         String title = "testTitle";
-        Images images = Images.generateImagesExcludeThumbnail(List.of("image1"));
+        Images images = new Images(List.of("image1"));
+
         PostForCreate postForCreate =
             new PostForCreate(1L, 2L, 3L, price, title, description, images);
         // When

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PriceTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/PriceTest.java
@@ -1,0 +1,21 @@
+package org.flab.hyunsb.domain.post;
+
+import org.flab.hyunsb.domain.post.exception.PostConstraintException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PriceTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 1_000_000_000})
+    @DisplayName("[Price 생성 실패 테스트] 범위를 벗어나는 가격이 주어진 경우 예외를 발생한다.")
+    public void createPrice_failureTest(int won) {
+        // Given & When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(PostConstraintException.class, () ->
+                new Price(won))
+        );
+    }
+}

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/vo/CountTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/vo/CountTest.java
@@ -1,0 +1,93 @@
+package org.flab.hyunsb.domain.post.vo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.flab.hyunsb.domain.post.exception.PostConstraintException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CountTest {
+
+    @Test
+    @DisplayName("[카운트 증가 성공 테스트] 카운트를 1 만큼 증가시킨다.")
+    public void increaseCount_successTest() {
+        // Given
+        int originCount = 1;
+        Count count = new Count(originCount);
+        // When
+        count.increaseCount();
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(2, count.getCount())
+        );
+    }
+
+    @Test
+    @DisplayName("[카운트 증가 성공 테스트] 카운트를 일정 수 만큼 증가시킨다.")
+    public void increaseCount_successTest_withIncreaseNumber() {
+        // Given
+        int originCount = 1;
+        Count count = new Count(originCount);
+        int numberForIncreaseCount = 3;
+        // When
+        count.increaseCount(numberForIncreaseCount);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(4, count.getCount())
+        );
+    }
+    @Test
+    @DisplayName("[카운트 증감 실패 테스트] 카운트 변경 수치로 음수를 전달한 경우 예외를 발생한다.")
+    public void changeCount_failureTest_requestNegativeNumber() {
+        // Given
+        int originCount = 0;
+        Count count = new Count(originCount);
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(PostConstraintException.class, () ->
+                count.decreaseCount(-1))
+        );
+    }
+
+    @Test
+    @DisplayName("[카운트 감소 성공 테스트] 카운트를 1 만큼 감소시킨다.")
+    public void decreaseCount_successTest() {
+        // Given
+        int originCount = 1;
+        Count count = new Count(originCount);
+        // When
+        count.decreaseCount();
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(0, count.getCount())
+        );
+    }
+
+    @Test
+    @DisplayName("[카운트 감소 성공 테스트] 카운트를 일정 수 만큼 감소시킨다.")
+    public void decreaseCount_successTest_withIncreaseNumber() {
+        // Given
+        int originCount = 3;
+        Count count = new Count(originCount);
+        int numberForIncreaseCount = 2;
+        // When
+        count.decreaseCount(numberForIncreaseCount);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(1, count.getCount())
+        );
+    }
+
+    @Test
+    @DisplayName("[카운트 감소 실패 테스트] 카운트 감소 시 카운트가 0 미만이 되는 경우 예외를 발생한다.")
+    public void decreaseCount_failureTest_countIsSmallerThanMinimum() {
+        // Given
+        int originCount = 0;
+        Count count = new Count(originCount);
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(PostConstraintException.class, count::decreaseCount)
+        );
+    }
+}

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/vo/ImagesTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/vo/ImagesTest.java
@@ -1,7 +1,5 @@
 package org.flab.hyunsb.domain.post.vo;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.List;
 import org.flab.hyunsb.domain.post.exception.PostConstraintException;
 import org.junit.jupiter.api.Assertions;
@@ -16,7 +14,7 @@ class ImagesTest {
         // Given
         List<String> imageUrls = List.of("image1", "image2", "image3");
         // When
-        Images images = Images.generateImagesExcludeThumbnail(imageUrls);
+        Images images = new Images(imageUrls);
         // Then
         Assertions.assertAll(
             () -> Assertions.assertEquals("image1", images.getThumbnail()),
@@ -31,7 +29,7 @@ class ImagesTest {
         int thumbnailNumber = 2;
         List<String> imageUrls = List.of("image1", "image2", "image3");
         // When
-        Images images = Images.generateImagesIncludeThumbnail(thumbnailNumber, imageUrls);
+        Images images = new Images(thumbnailNumber, imageUrls);
         // Then
         Assertions.assertAll(
             () -> Assertions.assertEquals("image3", images.getThumbnail()),
@@ -47,7 +45,7 @@ class ImagesTest {
         // When & Then
         Assertions.assertAll(
             () -> Assertions.assertThrows(PostConstraintException.class, () ->
-                Images.generateImagesExcludeThumbnail(emptyList))
+                new Images(emptyList))
         );
     }
 
@@ -61,7 +59,7 @@ class ImagesTest {
         // When & Then
         Assertions.assertAll(
             () -> Assertions.assertThrows(PostConstraintException.class, () ->
-                Images.generateImagesIncludeThumbnail(thumbnailNumber, imageUrls))
+                new Images(thumbnailNumber, imageUrls))
         );
     }
 }

--- a/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/vo/ImagesTest.java
+++ b/used-trading-domain/src/test/java/org/flab/hyunsb/domain/post/vo/ImagesTest.java
@@ -1,0 +1,67 @@
+package org.flab.hyunsb.domain.post.vo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.flab.hyunsb.domain.post.exception.PostConstraintException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ImagesTest {
+
+    @Test
+    @DisplayName("[이미지 생성 성공 테스트] 썸네일 정보가 포함되지 않은 이미지 생성 시 첫 번째 이미지를 썸네일로 지정한다.")
+    public void imagesGeneration_successTest_excludeThumbnail() {
+        // Given
+        List<String> imageUrls = List.of("image1", "image2", "image3");
+        // When
+        Images images = Images.generateImagesExcludeThumbnail(imageUrls);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals("image1", images.getThumbnail()),
+            () -> Assertions.assertEquals(imageUrls, images.getImages())
+        );
+    }
+
+    @Test
+    @DisplayName("[이미지 생성 성공 테스트] 썸네일 정보가 포함된 이미지를 생성한다.")
+    public void imagesGeneration_successTest_includeThumbnail() {
+        // Given
+        int thumbnailNumber = 2;
+        List<String> imageUrls = List.of("image1", "image2", "image3");
+        // When
+        Images images = Images.generateImagesIncludeThumbnail(thumbnailNumber, imageUrls);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals("image3", images.getThumbnail()),
+            () -> Assertions.assertEquals(imageUrls, images.getImages())
+        );
+    }
+
+    @Test
+    @DisplayName("[이미지 생성 실패 테스트] 이미지 리스트가 빈 경우 예외를 발생한다.")
+    public void imagesGeneration_failureTest_emptyImages() {
+        // Given
+        List<String> emptyList = List.of();
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(PostConstraintException.class, () ->
+                Images.generateImagesExcludeThumbnail(emptyList))
+        );
+    }
+
+    @Test
+    @DisplayName("[이미지 생성 실패 테스트] 썸네일 번호가 이미지 개수보다 큰 경우 예외를 발생한다.")
+    public void imagesGeneration_successTest_invalidThumbnailNumber() {
+        // Given
+        List<String> imageUrls = List.of("image1", "image2", "image3");
+        int thumbnailNumber = imageUrls.size() + 1;
+
+        // When & Then
+        Assertions.assertAll(
+            () -> Assertions.assertThrows(PostConstraintException.class, () ->
+                Images.generateImagesIncludeThumbnail(thumbnailNumber, imageUrls))
+        );
+    }
+}

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/adapter/CategoryPersistenceAdapter.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/adapter/CategoryPersistenceAdapter.java
@@ -1,0 +1,22 @@
+package org.flab.hyunsb.framework.persistence.adapter;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.flab.hyunsb.application.output.CategoryOutputPort;
+import org.flab.hyunsb.framework.persistence.entity.post.CategoryEntity;
+import org.flab.hyunsb.framework.persistence.repository.CategoryRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryPersistenceAdapter implements CategoryOutputPort {
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Optional<Long> findIdById(Long id) {
+        return categoryRepository.findById(id)
+            .map(CategoryEntity::getId)
+            .or(Optional::empty);
+    }
+}

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapter.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapter.java
@@ -1,0 +1,32 @@
+package org.flab.hyunsb.framework.persistence.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.flab.hyunsb.application.output.PostOutputPort;
+import org.flab.hyunsb.domain.post.Post;
+import org.flab.hyunsb.framework.persistence.entity.post.ImageEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.flab.hyunsb.framework.persistence.repository.ImageRepository;
+import org.flab.hyunsb.framework.persistence.repository.PostRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PostPersistenceAdapter implements PostOutputPort {
+
+    private final PostRepository postRepository;
+    private final ImageRepository imageRepository;
+
+    @Override
+    @Transactional
+    public Long savePost(Post post) {
+        PostEntity postEntity = PostEntity.from(post);
+
+        postEntity = postRepository.save(postEntity);
+
+        Long postId = postEntity.getId();
+        imageRepository.saveAll(ImageEntity.from(postId, post.getImages()));
+
+        return postId;
+    }
+}

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/member/MemberEntity.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/member/MemberEntity.java
@@ -42,6 +42,10 @@ public class MemberEntity extends BaseTimeEntity {
     @Column(nullable = false)
     private String nickname;
 
+    private MemberEntity(Long id) {
+        this.id = id;
+    }
+
     public Member toDomain() {
         return new Member(id, region.getId(), email, Password.valueOf(password), nickname);
     }
@@ -54,5 +58,9 @@ public class MemberEntity extends BaseTimeEntity {
             member.getPassword(),
             member.getNickname()
         );
+    }
+
+    public static MemberEntity valueOf(Long id) {
+        return new MemberEntity(id);
     }
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/CategoryEntity.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/CategoryEntity.java
@@ -23,4 +23,12 @@ public class CategoryEntity extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    private CategoryEntity(Long id) {
+        this.id = id;
+    }
+
+    public static CategoryEntity valueOf(Long id) {
+        return new CategoryEntity(id);
+    }
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/ImageEntity.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/ImageEntity.java
@@ -19,7 +19,6 @@ import org.flab.hyunsb.domain.post.vo.Images;
 import org.flab.hyunsb.framework.persistence.entity.basetime.BaseTimeEntity;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity(name = "image")

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/ImageEntity.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/ImageEntity.java
@@ -8,12 +8,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.flab.hyunsb.domain.post.vo.Images;
 import org.flab.hyunsb.framework.persistence.entity.basetime.BaseTimeEntity;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity(name = "image")
@@ -30,4 +36,14 @@ public class ImageEntity extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String imageUrl;
+
+    public static List<ImageEntity> from(Long postId, Images images) {
+        return images.getImages().stream()
+            .map(image -> ImageEntity.from(postId, image))
+            .collect(Collectors.toList());
+    }
+
+    private static ImageEntity from(Long postId, String image) {
+        return new ImageEntity(null, PostEntity.valueOf(postId), image);
+    }
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/PostEntity.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/PostEntity.java
@@ -12,9 +12,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.flab.hyunsb.domain.post.Post;
 import org.flab.hyunsb.framework.persistence.entity.basetime.BaseTimeEntity;
 import org.flab.hyunsb.framework.persistence.entity.member.MemberEntity;
 import org.flab.hyunsb.framework.persistence.entity.region.RegionEntity;
@@ -22,6 +25,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
 @DynamicUpdate
@@ -75,5 +79,24 @@ public class PostEntity extends BaseTimeEntity {
     private void prePersistence() {
         likeCount = 0;
         viewCount = 0;
+    }
+
+    public static PostEntity valueOf(Long id) {
+        return PostEntity.builder().id(id).build();
+    }
+
+    public static PostEntity from(Post post) {
+        return PostEntity.builder()
+            .category(CategoryEntity.valueOf(post.getCategoryId()))
+            .member(MemberEntity.valueOf(post.getMemberId()))
+            .region(RegionEntity.valueOf(post.getRegionId()))
+            .status(PostStatus.valueOf(post.getStatus()))
+            .title(post.getTitle())
+            .description(post.getDescription())
+            .price(post.getPrice().getPrice())
+            .thumbnail(post.getImages().getThumbnail())
+            .likeCount(post.getLikeCount().getCount())
+            .viewCount(post.getViewCount().getCount())
+            .build();
     }
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/PostStatus.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/PostStatus.java
@@ -2,6 +2,7 @@ package org.flab.hyunsb.framework.persistence.entity.post;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.flab.hyunsb.domain.post.vo.Status;
 
 @Getter
 @RequiredArgsConstructor
@@ -13,4 +14,8 @@ public enum PostStatus {
     HIDE("숨김");
 
     private final String status;
+
+    public static PostStatus valueOf(Status status) {
+        return PostStatus.valueOf(status.name());
+    }
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/CategoryRepository.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.framework.persistence.repository;
+
+import org.flab.hyunsb.framework.persistence.entity.post.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+
+}

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/ImageRepository.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.framework.persistence.repository;
+
+import org.flab.hyunsb.framework.persistence.entity.post.ImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
+
+}

--- a/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/CategoryPersistenceAdapterTest.java
+++ b/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/CategoryPersistenceAdapterTest.java
@@ -1,0 +1,52 @@
+package org.flab.hyunsb.framework.persistence.adapter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+import org.flab.hyunsb.framework.persistence.entity.post.CategoryEntity;
+import org.flab.hyunsb.framework.persistence.repository.CategoryRepository;
+import org.flab.hyunsb.framework.repository.annotation.RepositoryTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class CategoryPersistenceAdapterTest {
+
+    @Autowired
+    private CategoryPersistenceAdapter categoryPersistenceAdapter;
+
+    private CategoryEntity categoryEntity;
+
+    @BeforeEach
+    void setUp(@Autowired CategoryRepository categoryRepository) {
+        CategoryEntity testCategory = new CategoryEntity(1L, "전자제품");
+        categoryEntity = categoryRepository.save(testCategory);
+    }
+
+    @Test
+    @DisplayName("[카테고리 아이디 조회 성공 테스트] 주어진 식별자로 검색한 카테고리의 Id를 반환한다.")
+    public void findIdByCategoryId_successTest_validId() {
+        // Given & When
+        Optional<Long> optionalId = categoryPersistenceAdapter.findIdById(categoryEntity.getId());
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertTrue(optionalId.isPresent()),
+            () -> Assertions.assertEquals(categoryEntity.getId(), optionalId.get())
+        );
+    }
+
+    @Test
+    @DisplayName("[카테고리 아이디 조회 성공 테스트] 식별자로 검색한 결과가 없는 경우 빈 Optioanl을 반환한다.")
+    public void findIdByCategoryId_successTest_invalidId() {
+        // Given & When
+        Long invalidId = categoryEntity.getId() + 1;
+        Optional<Long> optionalId = categoryPersistenceAdapter.findIdById(invalidId);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertFalse(optionalId.isPresent())
+        );
+    }
+}

--- a/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterTest.java
+++ b/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterTest.java
@@ -1,0 +1,64 @@
+package org.flab.hyunsb.framework.persistence.adapter;
+
+import java.util.List;
+import org.flab.hyunsb.domain.post.Post;
+import org.flab.hyunsb.domain.post.PostForCreate;
+import org.flab.hyunsb.domain.post.Price;
+import org.flab.hyunsb.domain.post.vo.Images;
+import org.flab.hyunsb.framework.persistence.entity.member.MemberEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.CategoryEntity;
+import org.flab.hyunsb.framework.persistence.entity.region.RegionEntity;
+import org.flab.hyunsb.framework.persistence.repository.CategoryRepository;
+import org.flab.hyunsb.framework.persistence.repository.MemberRepository;
+import org.flab.hyunsb.framework.persistence.repository.RegionRepository;
+import org.flab.hyunsb.framework.repository.annotation.RepositoryTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class PostPersistenceAdapterTest {
+
+    @Autowired
+    private PostPersistenceAdapter postPersistenceAdapter;
+
+    private RegionEntity testRegion;
+    private MemberEntity testMember;
+    private CategoryEntity testCategory;
+
+    @BeforeEach
+    void setUp(
+        @Autowired RegionRepository regionRepository,
+        @Autowired MemberRepository memberRepository,
+        @Autowired CategoryRepository categoryRepository) {
+
+        testRegion = regionRepository.save(new RegionEntity(1L, "경기도", "시흥시", 0.0, 0.0));
+
+        MemberEntity member = new MemberEntity(1L, testRegion, "email", "password", "nickname");
+        testMember = memberRepository.save(member);
+
+        testCategory = categoryRepository.save(new CategoryEntity(1L, "전자제품"));
+    }
+
+    @Test
+    @DisplayName("[post 생성 성공 테스트] post 도메인이 주어진 경우 post를 영속화 한 뒤 Id를 반환한다.")
+    public void Test() {
+        // Given
+        Images images = Images.generateImagesExcludeThumbnail(List.of("Image1", "Image1", "Image1"));
+        Price price = new Price(1000);
+
+        PostForCreate postForCreate = new PostForCreate(
+            testMember.getId(), testRegion.getId(), testCategory.getId(),
+            price, "title", "description", images);
+
+        Post post = Post.from(postForCreate);
+        // When
+        Long id = postPersistenceAdapter.savePost(post);
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(1L, id)
+        );
+    }
+}

--- a/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterTest.java
+++ b/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterTest.java
@@ -46,7 +46,7 @@ class PostPersistenceAdapterTest {
     @DisplayName("[post 생성 성공 테스트] post 도메인이 주어진 경우 post를 영속화 한 뒤 Id를 반환한다.")
     public void Test() {
         // Given
-        Images images = Images.generateImagesExcludeThumbnail(List.of("Image1", "Image1", "Image1"));
+        Images images = new Images(List.of("Image1", "Image1", "Image1"));
         Price price = new Price(1000);
 
         PostForCreate postForCreate = new PostForCreate(


### PR DESCRIPTION
## Description
로그인 프로세스를 구현한다.
- `POST` `/api/v1/posts` `HTTP 1.1`
- 사용자는 Access token과 상품 정보를 HTTP body에 담아 서버로 요청한다.
- 사용자의 Access token을 검증한다.
- 상품 도메인 엔티티를 생성하고 값을 검증하며 문제가 없을 시 영속화한다.
- 상품 등록 성공 시 상품의 ID 값을 반환한다.

<br>

## Issue
- #13 

<br>
resolved: #13 