### PR TITLE
[#15] 각종 상품 조회 프로세스 구현 

### DIFF
--- a/used-trading-bootstrap/build.gradle
+++ b/used-trading-bootstrap/build.gradle
@@ -7,6 +7,7 @@ configurations {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation:2.6.3'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/config/ActorTokenConfig.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/config/ActorTokenConfig.java
@@ -23,7 +23,7 @@ public class ActorTokenConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new ActorTokenAuthInterceptor(actorTokenAuthUseCase))
             .order(1)
-            .addPathPatterns("/**")
+            .addPathPatterns("/api/v1/posts/**")
             .excludePathPatterns("/error", "/api/v1/members/login", "/api/v1/members");
     }
 

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestQueryAdapter.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestQueryAdapter.java
@@ -1,0 +1,74 @@
+package org.flab.hyunsb.bootstrap.rest.adapter;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.flab.hyunsb.application.dto.Actor;
+import org.flab.hyunsb.bootstrap.rest.actortoken.LoginActor;
+import org.flab.hyunsb.bootstrap.rest.dto.post.PostDetailResponse;
+import org.flab.hyunsb.bootstrap.rest.dto.post.PostFindResponse;
+import org.flab.hyunsb.bootstrap.rest.exception.PostNotFoundException;
+import org.flab.hyunsb.framework.persistence.adapter.PostPersistenceAdapter;
+import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+@RestController
+public class PostRestQueryAdapter {
+
+    private final PostPersistenceAdapter postPersistenceAdapter;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    public List<PostFindResponse> findAll(@LoginActor Actor actor,
+        @PageableDefault Pageable pageable) {
+
+        List<PostEntity> posts = postPersistenceAdapter.findAllPost(actor.regionId(), pageable);
+
+        return posts.stream().map(PostFindResponse::from).toList();
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{postId}")
+    public PostDetailResponse findOne(@PathVariable(value = "postId") Long postId) {
+
+        PostEntity postEntity = postPersistenceAdapter.findOne(postId)
+            .orElseThrow(() -> new PostNotFoundException(postId));
+
+        return PostDetailResponse.from(postEntity);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/categories")
+    public List<PostFindResponse> findAllByCategoryId(
+        @LoginActor Actor actor, @PageableDefault Pageable pageable,
+        @RequestParam(name = "categoryId") Long categoryId) {
+
+        List<PostEntity> posts =
+            postPersistenceAdapter.findAllPostByCategoryId(actor.regionId(), categoryId, pageable);
+
+        return posts.stream().map(PostFindResponse::from).toList();
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/keywords")
+    public List<PostFindResponse> findAllByKeyword(
+        @LoginActor Actor actor, @PageableDefault Pageable pageable,
+        @RequestParam(name = "keyword") String keyword) {
+
+        List<PostEntity> posts =
+            postPersistenceAdapter.findAllPostByKeyword(actor.regionId(), keyword, pageable);
+
+        return posts.stream().map(PostFindResponse::from).toList();
+    }
+}

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostDetailResponse.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostDetailResponse.java
@@ -1,0 +1,46 @@
+package org.flab.hyunsb.bootstrap.rest.dto.post;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.flab.hyunsb.framework.persistence.entity.post.ImageEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostStatus;
+
+@Getter
+@AllArgsConstructor
+public class PostDetailResponse {
+
+    private final Long postId;
+    private final Long memberId;
+    private final Long regionId;
+    private final Long categoryId;
+
+    private final PostStatus status;
+    private final String title;
+    private final String description;
+    private final int price;
+
+    private final String thumbnail;
+    private final List<String> images;
+
+    private final int viewCount;
+    private final int likeCount;
+
+    private final LocalDateTime registrationAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static PostDetailResponse from(PostEntity post) {
+        List<String> images = post.getImages().stream().map(ImageEntity::getImageUrl).toList();
+        return new PostDetailResponse(
+            post.getId(), post.getMember().getId(),
+            post.getRegion().getId(), post.getCategory().getId(),
+            post.getStatus(), post.getTitle(), post.getDescription(), post.getPrice(),
+            post.getThumbnail(), images,
+            post.getViewCount(), post.getLikeCount(),
+            post.getRegistrationAt(), post.getCreatedAt(), post.getUpdatedAt()
+        );
+    }
+}

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostFindResponse.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/dto/post/PostFindResponse.java
@@ -1,0 +1,41 @@
+package org.flab.hyunsb.bootstrap.rest.dto.post;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostStatus;
+
+@Getter
+@AllArgsConstructor
+public class PostFindResponse {
+
+    private final Long postId;
+    private final Long memberId;
+    private final Long regionId;
+    private final Long categoryId;
+
+    private final PostStatus status;
+    private final String title;
+    private final String description;
+    private final int price;
+
+    private final String thumbnail;
+    private final int viewCount;
+    private final int likeCount;
+
+    private final LocalDateTime registrationAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static PostFindResponse from(PostEntity post) {
+        return new PostFindResponse(
+            post.getId(), post.getMember().getId(),
+            post.getRegion().getId(), post.getCategory().getId(),
+            post.getStatus(), post.getTitle(), post.getDescription(),
+            post.getPrice(), post.getThumbnail(),
+            post.getViewCount(), post.getLikeCount(),
+            post.getRegistrationAt(), post.getCreatedAt(), post.getUpdatedAt()
+        );
+    }
+}

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/ExceptionControllerAdvice.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/ExceptionControllerAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -32,9 +33,10 @@ public class ExceptionControllerAdvice {
         );
     }
 
-    @ExceptionHandler({ConstraintException.class, PasswordConstraintException.class})
+    @ExceptionHandler({ConstraintException.class, PasswordConstraintException.class,
+        NotFoundException.class, MethodArgumentTypeMismatchException.class})
     public ErrorResponse constraintException(
-        ConstraintException exception, HttpServletRequest request) {
+        RuntimeException exception, HttpServletRequest request) {
         logError(exception, request.getRequestURL().toString());
 
         return ErrorResponse.create(exception, HttpStatus.BAD_REQUEST, exception.getMessage());

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/NotFoundException.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.bootstrap.rest.exception;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/PostNotFoundException.java
+++ b/used-trading-bootstrap/src/main/java/org/flab/hyunsb/bootstrap/rest/exception/PostNotFoundException.java
@@ -1,0 +1,8 @@
+package org.flab.hyunsb.bootstrap.rest.exception;
+
+public class PostNotFoundException extends NotFoundException {
+
+    public PostNotFoundException(Long postId) {
+        super("postId에 해당하는 게시글이 존재하지 않습니다. : " + postId);
+    }
+}

--- a/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestQueryAdapterTest.java
+++ b/used-trading-bootstrap/src/test/java/org/flab/hyunsb/bootstrap/rest/adapter/PostRestQueryAdapterTest.java
@@ -1,0 +1,173 @@
+package org.flab.hyunsb.bootstrap.rest.adapter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.flab.hyunsb.application.dto.Actor;
+import org.flab.hyunsb.application.usecase.member.ActorTokenAuthUseCase;
+import org.flab.hyunsb.bootstrap.config.ActorTokenConfig;
+import org.flab.hyunsb.bootstrap.restdocs.AbstractRestDocsTests;
+import org.flab.hyunsb.framework.persistence.adapter.PostPersistenceAdapter;
+import org.flab.hyunsb.framework.persistence.entity.member.MemberEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.CategoryEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostStatus;
+import org.flab.hyunsb.framework.persistence.entity.region.RegionEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(PostRestQueryAdapter.class)
+class PostRestQueryAdapterTest extends AbstractRestDocsTests {
+
+    @MockBean
+    private PostPersistenceAdapter postPersistenceAdapter;
+
+    @MockBean
+    private ActorTokenAuthUseCase actorTokenAuthUseCase;
+
+    private long sequence;
+
+    @Test
+    @DisplayName("[게시글 전체 조회 핸들러 성공 테스트] 토큰에 존재하는 지역정보를 기반으로 전체 게시글을 조회한다.")
+    public void findAllPost_successTest() throws Exception {
+        // Given
+        String requestUrl = "/api/v1/posts";
+        String testToken = "testToken";
+
+        when(actorTokenAuthUseCase.authenticate(anyString()))
+            .thenReturn(new Actor(1L, 1L));
+
+        List<PostEntity> mockPostEntities = generateTestPostEntities(10);
+        when(postPersistenceAdapter.findAllPost(anyLong(), any(Pageable.class)))
+            .thenReturn(mockPostEntities);
+
+        // When & Then
+        mockMvc.perform(get(requestUrl)
+                .header(ActorTokenConfig.ACTOR_TOKEN_HEADER, testToken)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(10));
+    }
+
+    private List<PostEntity> generateTestPostEntities(int number) {
+        List<PostEntity> postEntities = new ArrayList<>();
+        for (int i = 0; i < number; i++) {
+            postEntities.add(new PostEntity(
+                sequence++, CategoryEntity.valueOf(1L),
+                MemberEntity.valueOf(1L), RegionEntity.valueOf(1L),
+                PostStatus.SELLING, "TestTitle", "TestDescription", 1000,
+                "TestThumbnail", List.of(), 1, 1,
+                LocalDateTime.now()
+            ));
+        }
+        return postEntities;
+    }
+
+    @Test
+    @DisplayName("[게시글 상세 조회 핸들러 성공 테스트] 게시글 아이디를 기반으로 상세 데이터를 조회한다.")
+    public void findOnePost_successTest() throws Exception {
+        // Given
+        String requestUrl = "/api/v1/posts/{postId}";
+        Long postId = 1L;
+        String testToken = "testToken";
+
+        when(actorTokenAuthUseCase.authenticate(anyString()))
+            .thenReturn(new Actor(1L, 1L));
+
+        PostEntity postEntity = generateTestPostEntities(1).get(0);
+        when(postPersistenceAdapter.findOne(anyLong()))
+            .thenReturn(Optional.of(postEntity));
+
+        // When & Then
+        mockMvc.perform(get(requestUrl, postId)
+                .header(ActorTokenConfig.ACTOR_TOKEN_HEADER, testToken)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(15))
+            .andExpect(jsonPath("$.memberId").value(1));
+    }
+
+    @Test
+    @DisplayName("[게시글 상세 조회 핸들러 실패 테스트] 유효하지 않은 게시글 아이디가 주어진 경우 예외를 발생한다.")
+    public void findOnePost_failureTest_invalidPostId() throws Exception {
+        // Given
+        String requestUrl = "/api/v1/posts/{postId}";
+        Long invalidPostId = 1L;
+        String testToken = "testToken";
+
+        when(actorTokenAuthUseCase.authenticate(anyString()))
+            .thenReturn(new Actor(1L, 1L));
+
+        when(postPersistenceAdapter.findOne(anyLong()))
+            .thenReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(get(requestUrl, invalidPostId)
+                .header(ActorTokenConfig.ACTOR_TOKEN_HEADER, testToken)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[게시글 카테고리 검색 핸들러 성공 테스트] 카테고리 아이디를 기반으로 포스트를 조회한다.")
+    public void findPostByCategory_successTest() throws Exception {
+        // Given
+        String requestUrl = "/api/v1/posts/categories";
+        Long categoryId = 1L;
+        String testToken = "testToken";
+
+        when(actorTokenAuthUseCase.authenticate(anyString()))
+            .thenReturn(new Actor(1L, 1L));
+
+        List<PostEntity> mockPostEntities = generateTestPostEntities(10);
+        when(postPersistenceAdapter.findAllPostByCategoryId(
+            anyLong(), anyLong(), any(Pageable.class))
+        ).thenReturn(mockPostEntities);
+
+        // When & Then
+        mockMvc.perform(get(requestUrl)
+                .param("categoryId", String.valueOf(categoryId))
+                .header(ActorTokenConfig.ACTOR_TOKEN_HEADER, testToken)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(10));
+    }
+
+    @Test
+    @DisplayName("[게시글 키워드 검색 핸들러 성공 테스트] 키워드를 기반으로 포스트를 조회한다.")
+    public void findPostByKeyword_successTest() throws Exception {
+        // Given
+        String requestUrl = "/api/v1/posts/keywords";
+        String keyword = "keyword";
+        String testToken = "testToken";
+
+        when(actorTokenAuthUseCase.authenticate(anyString()))
+            .thenReturn(new Actor(1L, 1L));
+
+        List<PostEntity> mockPostEntities = generateTestPostEntities(10);
+        when(postPersistenceAdapter.findAllPostByKeyword(
+            anyLong(), anyString(), any(Pageable.class))
+        ).thenReturn(mockPostEntities);
+
+        // When & Then
+        mockMvc.perform(get(requestUrl)
+                .param("keyword", keyword)
+                .header(ActorTokenConfig.ACTOR_TOKEN_HEADER, testToken)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(10));
+    }
+}

--- a/used-trading-domain/src/main/java/org/flab/hyunsb/domain/member/Member.java
+++ b/used-trading-domain/src/main/java/org/flab/hyunsb/domain/member/Member.java
@@ -27,11 +27,12 @@ public class Member {
         );
     }
 
-    public void tryToLogin(MemberForLogin memberForLogin) {
+    public Member tryToLogin(MemberForLogin memberForLogin) throws LoginFailureException {
         if (!isMatchingEmail(memberForLogin.email()) ||
             !password.isMatch(memberForLogin.password())) {
             throw new LoginFailureException();
         }
+        return this;
     }
 
     private boolean isMatchingEmail(String email) {
@@ -42,10 +43,11 @@ public class Member {
         return password.getPassword();
     }
 
-    public void changePassword(String currentPassword, String newPassword) {
+    public Member changePassword(String currentPassword, String newPassword) throws MemberAuthException {
         if (!password.isMatch(currentPassword)) {
             throw new MemberAuthException(PASSWORD_NOT_MATCHED);
         }
         password = Password.generateWithEncrypting(newPassword);
+        return this;
     }
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapter.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package org.flab.hyunsb.framework.persistence.adapter;
 
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.flab.hyunsb.application.output.PostOutputPort;
 import org.flab.hyunsb.domain.post.Post;
@@ -7,6 +9,8 @@ import org.flab.hyunsb.framework.persistence.entity.post.ImageEntity;
 import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
 import org.flab.hyunsb.framework.persistence.repository.ImageRepository;
 import org.flab.hyunsb.framework.persistence.repository.PostRepository;
+import org.flab.hyunsb.framework.persistence.repository.RegionRepository;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +20,7 @@ public class PostPersistenceAdapter implements PostOutputPort {
 
     private final PostRepository postRepository;
     private final ImageRepository imageRepository;
+    private final RegionRepository regionRepository;
 
     @Override
     @Transactional
@@ -28,5 +33,29 @@ public class PostPersistenceAdapter implements PostOutputPort {
         imageRepository.saveAll(ImageEntity.from(postId, post.getImages()));
 
         return postId;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostEntity> findAllPost(Long regionId, Pageable pageable) {
+        List<Long> regionIds = findNearFiveRegionFrom(regionId);
+        return postRepository.findByRegionIdIn(regionIds, pageable);
+    }
+
+    private List<Long> findNearFiveRegionFrom(Long regionId) {
+        return regionRepository.findNearFiveByRegionIdFrom(regionId);
+    }
+
+    public Optional<PostEntity> findOne(Long postId) {
+        return postRepository.findByPostId(postId);
+    }
+
+    public List<PostEntity> findAllPostByCategoryId(Long regionId, Long categoryId, Pageable pageable) {
+        List<Long> regionIds = findNearFiveRegionFrom(regionId);
+        return postRepository.findByCategoryIdAndRegionIdIn(categoryId, regionIds, pageable);
+    }
+
+    public List<PostEntity> findAllPostByKeyword(Long regionId, String keyword, Pageable pageable) {
+        List<Long> regionIds = findNearFiveRegionFrom(regionId);
+        return postRepository.findByKeywordAndRegionIdIn(keyword, regionIds, pageable);
     }
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/ImageEntity.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/ImageEntity.java
@@ -29,7 +29,7 @@ public class ImageEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @JoinColumn(nullable = false)
+    @JoinColumn(nullable = false, name = "post_post_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private PostEntity post;
 

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/PostEntity.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/entity/post/PostEntity.java
@@ -10,8 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -64,6 +66,9 @@ public class PostEntity extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String thumbnail;
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private List<ImageEntity> images;
 
     @Column(nullable = false)
     private Integer likeCount;

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/PostRepository.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/PostRepository.java
@@ -1,8 +1,56 @@
 package org.flab.hyunsb.framework.persistence.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
+    @Query(value = """
+            select p
+            from post p
+            where p.region.id in (:regionIds)
+                and p.status not in ('HIDE', 'SOLD')
+            order by p.updatedAt
+         """)
+    List<PostEntity> findByRegionIdIn(@Param("regionIds") List<Long> regionIds, Pageable pageable);
+
+    @Query(value = """
+            select p
+            from post p
+            join fetch p.images i
+            where p.id = :postId
+        """)
+    Optional<PostEntity> findByPostId(@Param("postId") Long postId);
+
+    @Query(value = """
+            select p
+            from post p
+            where p.region.id in (:regionIds)
+                and p.category.id = :categoryId
+                and p.status not in ('HIDE', 'SOLD')
+            order by p.updatedAt
+        """)
+    List<PostEntity> findByCategoryIdAndRegionIdIn(
+        @Param("categoryId") Long categoryId,
+        @Param("regionIds") List<Long> regionIds,
+        Pageable pageable);
+
+    @Query(value = """
+            select p
+            from post p
+            join category c on c.id = p.category.id
+            where concat(p.title, p.description, c.name) like %:keyword%
+                and p.region.id in (:regionIds) and p.status not in ('HIDE', 'SOLD')
+            order by p.updatedAt
+        """)
+    List<PostEntity> findByKeywordAndRegionIdIn(
+        @Param("keyword") String keyword,
+        @Param("regionIds") List<Long> regionIds,
+        Pageable pageable
+    );
 }

--- a/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/RegionRepository.java
+++ b/used-trading-framework/src/main/java/org/flab/hyunsb/framework/persistence/repository/RegionRepository.java
@@ -1,8 +1,22 @@
 package org.flab.hyunsb.framework.persistence.repository;
 
+import java.util.List;
 import org.flab.hyunsb.framework.persistence.entity.region.RegionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RegionRepository extends JpaRepository<RegionEntity, Long> {
 
+
+    @Query(value = """
+        select r.id
+        from region r, 
+            (select tr.lat as tlat, tr.lng as tlng 
+                from region tr 
+                where tr.id = :regionId) t 
+        order by st_distance(point(r.lat, r.lng), point(t.tlat, t.tlng)) 
+        limit 5
+        """)
+    List<Long> findNearFiveByRegionIdFrom(@Param("regionId") Long regionId);
 }

--- a/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterQueryTest.java
+++ b/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterQueryTest.java
@@ -1,0 +1,109 @@
+package org.flab.hyunsb.framework.persistence.adapter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.util.List;
+import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.flab.hyunsb.framework.persistence.repository.ImageRepository;
+import org.flab.hyunsb.framework.persistence.repository.PostRepository;
+import org.flab.hyunsb.framework.persistence.repository.RegionRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+public class PostPersistenceAdapterQueryTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @InjectMocks
+    private PostPersistenceAdapter postPersistenceAdapter;
+
+    @Test
+    @DisplayName("[post 리스트 조회 성공 테스트] regionId를 기반으로 post리스트를 조회한뒤 반환한다.")
+    public void findAllByRegionId_successTest() {
+        // Given
+        Long regionId = 1L;
+        Pageable pageable = Pageable.ofSize(10);
+
+        Mockito.when(regionRepository.findNearFiveByRegionIdFrom(anyLong()))
+            .thenReturn(List.of(1L, 2L, 3L, 4L, 5L));
+
+        Mockito.when(postRepository.findByRegionIdIn(anyList(), any(Pageable.class)))
+            .thenReturn(List.of(new PostEntity(), new PostEntity(), new PostEntity()));
+
+        // When
+        List<PostEntity> posts = postPersistenceAdapter.findAllPost(regionId, pageable);
+
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(3, posts.size())
+        );
+    }
+
+    @Test
+    @DisplayName("[post 리스트 조회 성공 테스트] categoryId를 기반으로 post리스트를 조회한 뒤 반환한다.")
+    public void findAllByCategoryIdAndRegionId_successTest() {
+        // Given
+        Long regionId = 1L;
+        Long categoryId = 1L;
+        Pageable pageable = Pageable.ofSize(10);
+
+        Mockito.when(regionRepository.findNearFiveByRegionIdFrom(anyLong()))
+            .thenReturn(List.of(1L, 2L, 3L, 4L, 5L));
+
+        Mockito.when(postRepository.findByCategoryIdAndRegionIdIn(
+            anyLong(), anyList(), any(Pageable.class))
+        ).thenReturn(List.of(new PostEntity(), new PostEntity(), new PostEntity()));
+
+        // When
+        List<PostEntity> posts =
+            postPersistenceAdapter.findAllPostByCategoryId(categoryId, regionId, pageable);
+
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(3, posts.size())
+        );
+    }
+
+    @Test
+    @DisplayName("[post 리스트 조회 성공 테스트] keyword를 기반으로 post리스트를 조회한 뒤 반환한다.")
+    public void findAllByKeywordAndRegionId_successTest() {
+        // Given
+        Long regionId = 1L;
+        String keyword = "keyword";
+        Pageable pageable = Pageable.ofSize(10);
+
+        Mockito.when(regionRepository.findNearFiveByRegionIdFrom(anyLong()))
+            .thenReturn(List.of(1L, 2L, 3L, 4L, 5L));
+
+        Mockito.when(postRepository.findByKeywordAndRegionIdIn(
+            anyString(), anyList(), any(Pageable.class))
+        ).thenReturn(List.of(new PostEntity(), new PostEntity(), new PostEntity()));
+
+        // When
+        List<PostEntity> posts =
+            postPersistenceAdapter.findAllPostByKeyword(regionId, keyword, pageable);
+
+        // Then
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(3, posts.size())
+        );
+    }
+}

--- a/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterTest.java
+++ b/used-trading-framework/src/test/java/org/flab/hyunsb/framework/persistence/adapter/PostPersistenceAdapterTest.java
@@ -1,5 +1,7 @@
 package org.flab.hyunsb.framework.persistence.adapter;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import org.flab.hyunsb.domain.post.Post;
 import org.flab.hyunsb.domain.post.PostForCreate;
@@ -7,9 +9,12 @@ import org.flab.hyunsb.domain.post.Price;
 import org.flab.hyunsb.domain.post.vo.Images;
 import org.flab.hyunsb.framework.persistence.entity.member.MemberEntity;
 import org.flab.hyunsb.framework.persistence.entity.post.CategoryEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostEntity;
+import org.flab.hyunsb.framework.persistence.entity.post.PostStatus;
 import org.flab.hyunsb.framework.persistence.entity.region.RegionEntity;
 import org.flab.hyunsb.framework.persistence.repository.CategoryRepository;
 import org.flab.hyunsb.framework.persistence.repository.MemberRepository;
+import org.flab.hyunsb.framework.persistence.repository.PostRepository;
 import org.flab.hyunsb.framework.persistence.repository.RegionRepository;
 import org.flab.hyunsb.framework.repository.annotation.RepositoryTest;
 import org.junit.jupiter.api.Assertions;
@@ -17,12 +22,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 
 @RepositoryTest
 class PostPersistenceAdapterTest {
 
     @Autowired
     private PostPersistenceAdapter postPersistenceAdapter;
+
+    @Autowired
+    private PostRepository postRepository;
 
     private RegionEntity testRegion;
     private MemberEntity testMember;
@@ -44,7 +53,7 @@ class PostPersistenceAdapterTest {
 
     @Test
     @DisplayName("[post 생성 성공 테스트] post 도메인이 주어진 경우 post를 영속화 한 뒤 Id를 반환한다.")
-    public void Test() {
+    public void savePost_successTest() {
         // Given
         Images images = new Images(List.of("Image1", "Image1", "Image1"));
         Price price = new Price(1000);


### PR DESCRIPTION
## Description
상품 조회 프로세스를 구현한다.
조회 프로세스는 domain과 application 모듈 코드를 작성하지 않고, 
Inbound Adapter 에서 Outbound Adapter 와 직접 통신한다.
변경 가능성(UI의 변경 가능성이 높을 것)을 고려하여 의존 방향은 제어 흐름과 동일하게 가져간다.


- 지역 위치 기반 전체 상품 조회 
  - `GET` `/api/v1/posts` `HTTP 1.1` 
- 특정 상품 조회
  - `GET` `/api/v1/posts/{postId}` `HTTP 1.1`
- 키워드 검색
  - `GET` `/api/v1/posts/keywords?keyword={}` `HTTP 1.1` 
- 카테고리 검색
  - `GET` `/api/v1/posts/categories?catedoryId={}` `HTTP 1.1`


<br>

## Issue
- #15 

<br>
resolved: #15 